### PR TITLE
add site publication to gh-pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ dependency-reduced-pom.xml
 buildNumber.properties
 .mvn/timing.properties
 .mvn/wrapper/maven-wrapper.jar
+.apt_generated/
+.apt_generated_tests/
+bin/

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This is a Maven plugin that can be used to use the "keyless" signing paradigm supported by Sigstore to [sign JAR file](https://docs.oracle.com/javase/tutorial/deployment/jar/intro.html)
 with [`jarsigner`](https://docs.oracle.com/en/java/javase/11/tools/jarsigner.html). 
 
-Javadoc can be located at:  INSERT LINK HERE, but you can quickly take advantage of the plugin by adding the following configuration into your Maven POM.XML file:
+Full `sign` goal documentation is [available here](https://sigstore.github.io/sigstore-maven-plugin/sign-mojo.html), but you can quickly take advantage of the plugin by adding the following configuration into your Maven `pom.xml` file:
 
 ```xml
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,12 @@
 
   <name>sigstore Maven Plugin</name>
 
-  <url>https://sigstore.dev</url>
+  <url>https://sigstore.github.io/sigstore-maven-plugin/</url>
+
+  <organization>
+    <name>sigstore</name>
+    <url>https://sigstore.dev/</url>
+  </organization>
 
   <licenses>
     <license>
@@ -39,6 +44,17 @@
     <maven>${maven.version}</maven>
   </prerequisites>
 
+  <scm>
+    <connection>scm:git:https://github.com/sigstore/sigstore-maven-plugin.git</connection>
+    <developerConnection>scm:git:https://github.com/sigstore/sigstore-maven-plugin.git</developerConnection>
+    <url>https://github.com/sigstore/sigstore-maven-plugin/tree/${project.scm.tag}</url>
+    <tag>main</tag>
+  </scm>
+  <issueManagement>
+    <system>GitHub</system>
+    <url>https://github.com/sigstore/sigstore-maven-plugin/issues/</url>
+  </issueManagement>
+
   <distributionManagement>
     <snapshotRepository>
       <id>ossrh</id>
@@ -48,6 +64,10 @@
       <id>ossrh</id>
       <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
     </repository>
+    <site>
+      <id>gh-pages</id>
+      <url>scm:git:ssh://git@github.com/sigstore/sigstore-maven-plugin.git</url>
+    </site>
   </distributionManagement>
 
   <properties>
@@ -187,6 +207,14 @@
           <artifactId>maven-invoker-plugin</artifactId>
           <version>3.2.2</version>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-site-plugin</artifactId>
+          <version>3.11.0</version>
+          <configuration>
+            <skipDeploy>true</skipDeploy><!-- don't deploy site with maven-site-plugin -->
+          </configuration>
+        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>
@@ -248,8 +276,56 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-scm-publish-plugin</artifactId>
+        <version>3.1.0</version>
+        <configuration>
+          <scmBranch>gh-pages</scmBranch>
+          <content>${project.reporting.outputDirectory}</content>
+        </configuration>
+        <executions>
+          <execution>
+            <id>scm-publish</id>
+            <phase>site-deploy</phase><!-- deploy site with maven-scm-publish-plugin -->
+            <goals>
+              <goal>publish-scm</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
+
+  <reporting>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-project-info-reports-plugin</artifactId>
+        <reportSets>
+          <reportSet>
+            <reports>
+              <report>index</report>
+              <report>summary</report>
+              <report>dependency-info</report>
+              <report>team</report>
+              <report>scm</report>
+              <report>issue-management</report>
+              <report>dependency-management</report>
+              <report>dependencies</report>
+              <report>plugin-management</report>
+              <report>plugins</report>
+              <report>distribution-management</report>
+            </reports>
+          </reportSet>
+        </reportSets>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-plugin-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </reporting>
 
   <profiles>
     <profile>

--- a/src/site/markdown/index.md.vm
+++ b/src/site/markdown/index.md.vm
@@ -1,0 +1,41 @@
+<!---
+ Copyright 2022 The Sigstore Authors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+# sigstore-maven-plugin
+
+This is a Maven plugin that can be used to use the "keyless" signing paradigm supported by Sigstore, to [sign JAR file](https://docs.oracle.com/javase/tutorial/deployment/jar/intro.html). 
+
+```xml
+      <plugin>
+        <groupId>dev.sigstore</groupId>
+        <artifactId>sigstore-maven-plugin</artifactId>
+        <version>${project.version}</version>
+        <executions>
+          <execution>
+            <id>sigstore-sign</id>
+            <goals>
+              <goal>sign</goal>
+            </goals>
+            <!-- optional configuration parameters; sensible defaults are chosen
+            <configuration>
+              <emailAddress>YOUR-EMAIL-ADDRESS-HERE</emailAddress>
+              <outputSigningCert>signingCert.pem</outputSigningCert>
+              <sslVerification>false</sslVerification>
+            </configuration>
+            -->
+          </execution>
+        </executions>
+      </plugin>
+```

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -1,0 +1,52 @@
+<!--
+ Copyright 2022 The Sigstore Authors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/DECORATION/1.8.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/DECORATION/1.8.0 http://maven.apache.org/xsd/decoration-1.8.0.xsd">
+  <bannerLeft>
+    <name>${project.name}</name>
+    <src>https://next.redhat.com/wp-content/uploads/2021/10/Symbol_200x200.png</src>
+    <href>https://sigstore.dev/</href>
+  </bannerLeft>
+
+  <bannerRight>
+    <name>sigstore</name>
+    <href>https://sigstore.dev/</href>
+  </bannerRight>
+
+  <skin>
+    <groupId>org.apache.maven.skins</groupId>
+    <artifactId>maven-fluido-skin</artifactId>
+    <version>1.10.0</version>
+  </skin>
+
+  <edit>${project.scm.url}</edit>
+
+  <publishDate position="right" />
+  <version position="right" />
+
+  <body>
+    <breadcrumbs>
+      <item name="Sigstore" href="https://sigstore.github.io/" />
+      <item name="Maven plugin"  href="https://sigstore.github.io/sigstore-maven-plugin/" />
+    </breadcrumbs>
+
+    <menu name="Overview">
+      <item name="Introduction" href="index.html"/>
+      <item name="Goals" href="plugin-info.html"/>
+    </menu>
+    <menu ref="reports" />
+  </body>
+</project>


### PR DESCRIPTION
#### Summary
Add Maven site publication to GitHub Pages to benefit from plugin documentation

#### Ticket Link
Fixes

#### Release Note
```release-note
NONE
```


To locally test the site: `mvn clean site` then loook at `target/site`

To init the public site:
```
mvn clean site
git checkout --orphan gh-pages
rm .git/index
git add -f target/site/
git mv target/site/* .
git clean -fdx
git commit -m "initial site"
git push
```
the site will be visible at https://sigstore.github.io/sigstore-maven-plugin/

To update the site in the future: `mvn clean site-deploy`