### PR TITLE
Closes #77 - Using single property to define Java release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,8 +52,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.release>11</maven.compiler.release>
     <maven.version>3.8.4</maven.version>
   </properties>
 


### PR DESCRIPTION
#### Summary
Using singly property instead of two.

#### Fixes
https://github.com/sigstore/sigstore-maven-plugin/issues/79
