### PR TITLE
Add verify goal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,6 +164,21 @@
       <artifactId>maven-jarsigner</artifactId>
       <version>3.0.0</version>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <version>2.13.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.13.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcutil-jdk15on</artifactId>
+      <version>1.70</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/dev/sigstore/plugin/Verify.java
+++ b/src/main/java/dev/sigstore/plugin/Verify.java
@@ -1,0 +1,51 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package dev.sigstore.plugin;
+
+import java.io.File;
+
+import javax.inject.Inject;
+
+import dev.sigstore.plugin.verify.SigstoreVerifier;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Goal which:<ul>
+ * <li>verifies dependency signatures against fulco
+ * </ul>
+ */
+@Mojo(name = "verify", defaultPhase = LifecyclePhase.VERIFY)
+public class Verify
+    extends AbstractMojo
+{
+  private static final Logger LOG = LoggerFactory.getLogger(Verify.class);
+
+  @Parameter(property = "binary-file")
+  private File binaryFile;
+
+  @Inject
+  private SigstoreVerifier sigstoreVerifier;
+
+  @Override
+  public final void execute() throws MojoExecutionException {
+    sigstoreVerifier.verifySignature(binaryFile);
+  }
+}

--- a/src/main/java/dev/sigstore/plugin/client/SigstoreClient.java
+++ b/src/main/java/dev/sigstore/plugin/client/SigstoreClient.java
@@ -1,0 +1,150 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package dev.sigstore.plugin.client;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.sigstore.plugin.model.HashedRekord;
+import dev.sigstore.plugin.model.HashedRekordRequest;
+import dev.sigstore.plugin.model.HashedRekordUuidRequest;
+import dev.sigstore.plugin.model.HashedRekordWrapper;
+import dev.sigstore.plugin.model.TransparencyLogEntry;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toList;
+import static org.apache.http.entity.ContentType.APPLICATION_JSON;
+
+@Named
+@Singleton
+public class SigstoreClient
+{
+  private static final Logger LOG = LoggerFactory.getLogger(SigstoreClient.class);
+
+  private static final String TRANSPARENCY_LOG_INDEX_URL = "https://rekor.sigstore.dev/api/v1/index/retrieve";
+
+  private static final String TRANSPARENCY_LOG_ENTRY_URL = "https://rekor.sigstore.dev/api/v1/log/entries/retrieve";
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  public SigstoreClient() {
+    objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+  }
+  /*
+   * Send request off to sigstore to find any transparency logs for checksum
+   * example:
+   *
+   * POST https://rekor.sigstore.dev/api/v1/index/retrieve
+   * {
+   *   hash: "sha256:342024b59f3b8fe1a37efce6167023bc368f71ca01779ae81e78b2f4aca376be"
+   * }
+   */
+  public List<HashedRekordWrapper> getHashedRekordWrappersFromChecksum(
+      final String checksumType,
+      final String checksum)
+  {
+    try {
+      LOG.debug("Requesting transparency log records from {} for checksum {}:{}", TRANSPARENCY_LOG_INDEX_URL,
+          checksumType, checksum);
+
+      List<String> transparencyLogUuids = objectMapper.readValue(getJsonFromPOST(TRANSPARENCY_LOG_INDEX_URL,
+              objectMapper.writeValueAsString(new HashedRekordUuidRequest(String.format("%s:%s", checksumType, checksum)))),
+          new TypeReference<>() { });
+
+      LOG.debug("Found transparency log uuids: {}", transparencyLogUuids.toString());
+
+      return transparencyLogUuids.stream().map(this::getHashedRekordWrapperFromUuid).collect(toList());
+    }
+    catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /*
+   * Send request off to sigstore to grab the HashedRekord associated with a single uuid
+   * example:
+   *
+   * POST https://rekor.sigstore.dev/api/v1/log/entries/retrieve
+   * {
+   *   entryUUIDs: ["a9bd97ee5453ce44525069e8ff8703555bc28d9f1553b9745bd6cdff3732bb87"]
+   * }
+   */
+  private HashedRekordWrapper getHashedRekordWrapperFromUuid(final String uuid) {
+    try {
+      LOG.debug("Requesting transparency log record from {} for uuid {}", TRANSPARENCY_LOG_ENTRY_URL, uuid);
+
+      List<Map<String, Object>> hashedRekordWrapperList = objectMapper.readValue(
+          getJsonFromPOST(TRANSPARENCY_LOG_ENTRY_URL,
+              objectMapper.writeValueAsString(new HashedRekordRequest(singletonList(uuid)))),
+          new TypeReference<>() { });
+
+      LOG.debug("Found HashedRekordWrapper {} from uuid {}", hashedRekordWrapperList, uuid);
+
+      if (hashedRekordWrapperList.size() > 1) {
+        throw new RuntimeException(
+            String.format("Received %s results for uuid %s query.", hashedRekordWrapperList.size(), uuid));
+      }
+
+      TransparencyLogEntry transparencyLogEntry =
+          objectMapper.readValue(objectMapper.writeValueAsString(hashedRekordWrapperList.get(0).get(uuid)),
+              TransparencyLogEntry.class);
+
+      HashedRekord record = objectMapper.readValue(new String(Base64.decodeBase64(transparencyLogEntry.body), UTF_8),
+          HashedRekord.class);
+
+      return new HashedRekordWrapper(transparencyLogEntry.integratedTime, record,
+          new String(Base64.decodeBase64(record.spec.signature.publicKey.content), UTF_8),
+          new String(Base64.decodeBase64(record.spec.signature.content), UTF_8));
+    }
+    catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private String getJsonFromPOST(final String url, final String json) throws IOException {
+    try (final CloseableHttpClient httpClient = HttpClients.createDefault()) {
+      HttpPost post = new HttpPost(URI.create(url));
+      post.setEntity(new StringEntity(json, APPLICATION_JSON));
+
+      try (final CloseableHttpResponse httpResponse = httpClient.execute(post)) {
+        if (httpResponse.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
+          throw new RuntimeException(String.format("Failed to send POST request to %s status %d response %s", url,
+              httpResponse.getStatusLine().getStatusCode(), EntityUtils.toString(httpResponse.getEntity())));
+        }
+
+        return EntityUtils.toString(httpResponse.getEntity());
+      }
+    }
+  }
+}

--- a/src/main/java/dev/sigstore/plugin/model/HashedRekord.java
+++ b/src/main/java/dev/sigstore/plugin/model/HashedRekord.java
@@ -1,0 +1,33 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package dev.sigstore.plugin.model;
+
+public class HashedRekord
+{
+  public String apiVersion;
+
+  public String kind;
+
+  public HashedRekordSpec spec;
+
+  @Override
+  public String toString() {
+    return "HashedRekord{" +
+        "apiVersion='" + apiVersion + '\'' +
+        ", kind='" + kind + '\'' +
+        ", spec=" + spec +
+        '}';
+  }
+}

--- a/src/main/java/dev/sigstore/plugin/model/HashedRekordRequest.java
+++ b/src/main/java/dev/sigstore/plugin/model/HashedRekordRequest.java
@@ -1,0 +1,33 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package dev.sigstore.plugin.model;
+
+import java.util.List;
+
+public class HashedRekordRequest
+{
+  public List<String> entryUUIDs;
+
+  public HashedRekordRequest(final List<String> entryUUIDs) {
+    this.entryUUIDs = entryUUIDs;
+  }
+
+  @Override
+  public String toString() {
+    return "HashedRekordRequest{" +
+        "entryUUIDs=" + entryUUIDs +
+        '}';
+  }
+}

--- a/src/main/java/dev/sigstore/plugin/model/HashedRekordSpec.java
+++ b/src/main/java/dev/sigstore/plugin/model/HashedRekordSpec.java
@@ -1,0 +1,30 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package dev.sigstore.plugin.model;
+
+public class HashedRekordSpec
+{
+  public HashedRekordSpecData data;
+
+  public HashedRekordSpecSignature signature;
+
+  @Override
+  public String toString() {
+    return "HashedRekordSpec{" +
+        "data=" + data +
+        ", signature=" + signature +
+        '}';
+  }
+}

--- a/src/main/java/dev/sigstore/plugin/model/HashedRekordSpecData.java
+++ b/src/main/java/dev/sigstore/plugin/model/HashedRekordSpecData.java
@@ -1,0 +1,27 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package dev.sigstore.plugin.model;
+
+public class HashedRekordSpecData
+{
+  public HashedRekordSpecDataHash hash;
+
+  @Override
+  public String toString() {
+    return "HashedRekordSpecData{" +
+        "hash=" + hash +
+        '}';
+  }
+}

--- a/src/main/java/dev/sigstore/plugin/model/HashedRekordSpecDataHash.java
+++ b/src/main/java/dev/sigstore/plugin/model/HashedRekordSpecDataHash.java
@@ -1,0 +1,30 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package dev.sigstore.plugin.model;
+
+public class HashedRekordSpecDataHash
+{
+  public String algorithm;
+
+  public String value;
+
+  @Override
+  public String toString() {
+    return "HashedRekordSpecDataHash{" +
+        "algorithm='" + algorithm + '\'' +
+        ", value='" + value + '\'' +
+        '}';
+  }
+}

--- a/src/main/java/dev/sigstore/plugin/model/HashedRekordSpecSignature.java
+++ b/src/main/java/dev/sigstore/plugin/model/HashedRekordSpecSignature.java
@@ -1,0 +1,33 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package dev.sigstore.plugin.model;
+
+public class HashedRekordSpecSignature
+{
+  public String content;
+
+  public String format;
+
+  public HashedRekordSpecSignaturePublicKey publicKey;
+
+  @Override
+  public String toString() {
+    return "HashedRekordSpecSignature{" +
+        "content='" + content + '\'' +
+        ", format='" + format + '\'' +
+        ", publicKey=" + publicKey +
+        '}';
+  }
+}

--- a/src/main/java/dev/sigstore/plugin/model/HashedRekordSpecSignaturePublicKey.java
+++ b/src/main/java/dev/sigstore/plugin/model/HashedRekordSpecSignaturePublicKey.java
@@ -1,0 +1,27 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package dev.sigstore.plugin.model;
+
+public class HashedRekordSpecSignaturePublicKey
+{
+  public String content;
+
+  @Override
+  public String toString() {
+    return "HashedRekordSpecSignaturePublicKey{" +
+        "content='" + content + '\'' +
+        '}';
+  }
+}

--- a/src/main/java/dev/sigstore/plugin/model/HashedRekordUuidRequest.java
+++ b/src/main/java/dev/sigstore/plugin/model/HashedRekordUuidRequest.java
@@ -1,0 +1,31 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package dev.sigstore.plugin.model;
+
+public class HashedRekordUuidRequest
+{
+  public String hash;
+
+  public HashedRekordUuidRequest(final String hash) {
+    this.hash = hash;
+  }
+
+  @Override
+  public String toString() {
+    return "HashedRekordUuidRequest{" +
+        "hash='" + hash + '\'' +
+        '}';
+  }
+}

--- a/src/main/java/dev/sigstore/plugin/model/HashedRekordWrapper.java
+++ b/src/main/java/dev/sigstore/plugin/model/HashedRekordWrapper.java
@@ -1,0 +1,48 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package dev.sigstore.plugin.model;
+
+public class HashedRekordWrapper
+{
+  public Long integratedTime;
+
+  public HashedRekord hashedRekord;
+
+  public String decodedX509PublicSigningCertificate;
+
+  public String decodedSignature;
+
+  public HashedRekordWrapper(
+      final Long integratedTime,
+      final HashedRekord hashedRekord,
+      final String decodedX509PublicSigningCertificate,
+      final String decodedSignature)
+  {
+    this.integratedTime = integratedTime;
+    this.hashedRekord = hashedRekord;
+    this.decodedX509PublicSigningCertificate = decodedX509PublicSigningCertificate;
+    this.decodedSignature = decodedSignature;
+  }
+
+  @Override
+  public String toString() {
+    return "HashedRekordWrapper{" +
+        "integratedTime=" + integratedTime +
+        ", hashedRekord=" + hashedRekord +
+        ", decodedX509PublicSigningCertificate='" + decodedX509PublicSigningCertificate + '\'' +
+        ", decodedSignature='" + decodedSignature + '\'' +
+        '}';
+  }
+}

--- a/src/main/java/dev/sigstore/plugin/model/TransparencyLogEntry.java
+++ b/src/main/java/dev/sigstore/plugin/model/TransparencyLogEntry.java
@@ -1,0 +1,43 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package dev.sigstore.plugin.model;
+
+public class TransparencyLogEntry
+{
+  // ignore type that i don't know
+  //public Object attestation;
+
+  //base64-encoded HashedRekord
+  public String body;
+
+  public Long integratedTime;
+
+  public String logID;
+
+  public Long logIndex;
+
+  public TransparencyLogEntryVerification verification;
+
+  @Override
+  public String toString() {
+    return "TransparencyLogEntry{" +
+        "body='" + body + '\'' +
+        ", integratedTime=" + integratedTime +
+        ", logID='" + logID + '\'' +
+        ", logIndex=" + logIndex +
+        ", verification=" + verification +
+        '}';
+  }
+}

--- a/src/main/java/dev/sigstore/plugin/model/TransparencyLogEntryVerification.java
+++ b/src/main/java/dev/sigstore/plugin/model/TransparencyLogEntryVerification.java
@@ -1,0 +1,30 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package dev.sigstore.plugin.model;
+
+public class TransparencyLogEntryVerification
+{
+  // TODO: investigate type
+  //public Object inclusionProof;
+
+  public String signedEntryTimestamp;
+
+  @Override
+  public String toString() {
+    return "TransparencyLogEntryVerification{" +
+        "signedEntryTimestamp='" + signedEntryTimestamp + '\'' +
+        '}';
+  }
+}

--- a/src/main/java/dev/sigstore/plugin/verify/SigstoreVerifier.java
+++ b/src/main/java/dev/sigstore/plugin/verify/SigstoreVerifier.java
@@ -1,0 +1,129 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package dev.sigstore.plugin.verify;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.StringReader;
+import java.security.Signature;
+import java.security.cert.CertPath;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import com.google.api.client.util.PemReader;
+import com.google.api.client.util.PemReader.Section;
+import dev.sigstore.plugin.client.SigstoreClient;
+import dev.sigstore.plugin.model.HashedRekordWrapper;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.commons.codec.digest.MessageDigestAlgorithms.SHA_256;
+
+@Singleton
+@Named
+public class SigstoreVerifier
+{
+  private static final Logger LOG = LoggerFactory.getLogger(SigstoreVerifier.class);
+
+  @Inject
+  private SigstoreClient sigstoreClient;
+
+  public void verifySignature(final File binaryFile) {
+    try {
+      String sha256 = new DigestUtils(SHA_256).digestAsHex(binaryFile);
+
+      List<HashedRekordWrapper> rekords = sigstoreClient.getHashedRekordWrappersFromChecksum("sha256", sha256);
+
+      LOG.debug("Found rekords {}", rekords);
+
+      processRekords(binaryFile, sha256, rekords);
+    }
+    catch (IOException e) {
+      throw new RuntimeException("Failed to verify signature", e);
+    }
+  }
+
+  private void processRekords(
+      final File binaryFile,
+      final String sha256,
+      final List<HashedRekordWrapper> rekords)
+  {
+    rekords.forEach(rekord -> processRekord(binaryFile, sha256, rekord));
+  }
+
+  private void processRekord(
+      final File binaryFile,
+      final String sha256,
+      final HashedRekordWrapper rekord)
+  {
+    CertPath publicSigningCert = getSigningCert(rekord.decodedX509PublicSigningCertificate);
+
+    publicSigningCert.getCertificates()
+        .forEach(certificate -> processCert(binaryFile, sha256, rekord, certificate));
+  }
+
+  private void processCert(
+      final File binaryFile,
+      final String sha256,
+      final HashedRekordWrapper rekord,
+      final Certificate certificate)
+  {
+    try {
+      LOG.debug("Processing verification with cert {}", certificate);
+      //TODO: Figure out what i'm doing here, this sig validation isn't working as desired
+      Signature signature = Signature.getInstance(certificate.getPublicKey().getAlgorithm(), new BouncyCastleProvider());
+      signature.initVerify(certificate.getPublicKey());
+      signature.verify(rekord.decodedSignature.getBytes(UTF_8));
+    }
+    catch (Exception e) {
+      throw new RuntimeException("Failed to process the signature with cert", e);
+    }
+  }
+
+  private CertPath getSigningCert(final String publicSigningCert) {
+    try {
+      CertificateFactory cf = CertificateFactory.getInstance("X.509");
+      ArrayList<X509Certificate> certList = new ArrayList<>();
+      PemReader pemReader = new PemReader(new StringReader(publicSigningCert));
+      while (true) {
+        Section section = pemReader.readNextSection();
+        if (section == null) {
+          break;
+        }
+
+        byte[] certBytes = section.getBase64DecodedBytes();
+        certList.add((X509Certificate) cf.generateCertificate(new ByteArrayInputStream(certBytes)));
+      }
+      if (certList.isEmpty()) {
+        throw new IOException("no certificates were found in response from Fulcio instance");
+      }
+      return cf.generateCertPath(certList);
+    }
+    catch (Exception e) {
+      throw new RuntimeException("Failed to get signing certificate");
+    }
+  }
+}


### PR DESCRIPTION
#### Summary
Add `verify` goal for verifying signatures

#### WIP
Initial flow in place, down to the actual sig validation, working through that portion now, ultimately aiming to add similar functionality to the [pgp verifier plugin](https://github.com/s4u/pgpverify-maven-plugin) where it can validate the dependencies
And tests and all that jazz ;)