### PR TITLE
Updates to support TSA usage in jarsign goal

### DIFF
--- a/src/main/java/dev/sigstore/plugin/JarSign.java
+++ b/src/main/java/dev/sigstore/plugin/JarSign.java
@@ -196,7 +196,7 @@ public class JarSign extends AbstractMojo {
     /**
      * URL of Trusted Timestamp Authority (RFC3161 compliant)
      */
-    @Parameter(defaultValue = "https://rekor.sigstore.dev/api/v1/timestamp", property = "tsa-url", required = true)
+    @Parameter(property = "tsa-url")
     private URL tsaURL;
 
     public void execute() throws MojoExecutionException {
@@ -464,7 +464,7 @@ public class JarSign extends AbstractMojo {
                     .signatureAlgorithm("SHA256withECDSA").setProperty("internalsf", "true").signerName(signerName)
                     .eventHandler(progressLogger);
 
-            if (tsaURL.toString().equals("")) {
+            if (tsaURL != null && !tsaURL.toString().equals("")) {
                 jsb = jsb.tsa(tsaURL.toURI());
             }
 


### PR DESCRIPTION
#### Summary

Updates the integration of a Time Stamp Authority as part of the `jarsign` goal

* Existing functionality does not function properly as it is never possible to enable the  integration
* Existing functionality references a non existent Time Stamp Authority

 #120 

#### Release Note

* Corrects logic to how the jarsign goal integrates with a Time Stamp Authority
* Removes the use of a default Time Stamp Authority when using the jarsign goal

#### Documentation

No documentation related to the plugin are found on the sigstore documentation site
