### PR TITLE
force .sigstore.sha1 creation

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,1 +1,1 @@
--Daether.checksums.omitChecksumsForExtensions=.asc,.sigstore
+-Daether.checksums.omitChecksumsForExtensions=.asc


### PR DESCRIPTION
#### Summary
`.sigstore.sha1` fingerprints should not be required by Maven Central, but currently they are :/
forcing creation to let time to update the publication rules

#### Release Note

#### Documentation
