### PR TITLE
0.4.0 release done: now we can use it

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 sigstore-maven-plugin
 =====================
 
+[![Maven Central](https://img.shields.io/maven-central/v/dev.sigstore/sigstore-maven-plugin.svg?label=Maven%20Central)](https://central.sonatype.com/artifact/dev.sigstore/sigstore-maven-plugin)
+
 This is a Maven plugin that can be used to use the "keyless" signing paradigm supported by Sigstore.
 This plugin is still in early phases, then has known limitations described below.
 
@@ -11,7 +13,7 @@ sign
       <plugin>
         <groupId>dev.sigstore</groupId>
         <artifactId>sigstore-maven-plugin</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.0</version>
         <executions>
           <execution>
             <id>sign</id>
@@ -44,7 +46,7 @@ Full `jarsign` goal documentation is [available here](https://sigstore.github.io
       <plugin>
         <groupId>dev.sigstore</groupId>
         <artifactId>sigstore-maven-plugin</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.0</version>
         <executions>
           <execution>
             <id>sigstore-jarsign</id>

--- a/pom.xml
+++ b/pom.xml
@@ -460,9 +460,9 @@
             </executions>
           </plugin>
           <plugin>
-            <groupId>io.github.hboutemy</groupId><!-- use dev.sigstore when released -->
+            <groupId>dev.sigstore</groupId>
             <artifactId>sigstore-maven-plugin</artifactId>
-            <version>1.0.0-beta-3</version>
+            <version>0.4.0</version>
             <executions>
               <execution>
                 <id>sigstore-sign-release-artifacts</id>


### PR DESCRIPTION
#### Summary
use the 0.4.0 release that is now available in Maven Central https://repo.maven.apache.org/maven2/dev/sigstore/sigstore-maven-plugin/0.4.0/

#### Release Note

#### Documentation
