### PR TITLE
configure sign-off for commits by release plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -273,6 +273,8 @@
           <version>3.0.1</version>
           <configuration>
             <releaseProfiles>release</releaseProfiles>
+            <scmReleaseCommitComment>@{prefix} prepare release @{releaseLabel}&#xA;&#xA;Signed-off-by: Maven Release Plugin &lt;release@github.com&gt;</scmReleaseCommitComment>
+            <scmDevelopmentCommitComment>@{prefix} prepare for next development iteration&#xA;&#xA;Signed-off-by: Maven Release Plugin &lt;release@github.com&gt;</scmDevelopmentCommitComment>
           </configuration>
         </plugin>
       </plugins>


### PR DESCRIPTION
#### Summary
Given Git repository configuration required sign-off for every commit, maven-release-plugin must conform

#### Release Note

#### Documentation